### PR TITLE
git-archive replaces zip command in entrypoint docker shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.color"="orange"
 LABEL "repository"="https://github.com/shanemadden/factorio-mod-portal-publish"
 LABEL "maintainer"="Shane Madden"
 
-RUN apt-get update && apt-get -y install curl zip jq
+RUN apt-get update && apt-get -y install curl zip jq git
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -27,4 +27,11 @@ An example workflow to publish tagged releases:
 
 `FACTORIO_USER` and `FACTORIO_PASSWORD` secrets should be valid credentials to the Factorio mod portal with permissions to edit the mod defined in info.json.
 
+A valid .gitattributes file is required to filter .git*/* directories. This file must be checked in and tagged to filter during a git-archive operation.
+
+    .gitattributes export-ignore
+    .gitignore export-ignore
+    .github export-ignore
+
+
 Be aware that the zip will be published and immediately available for download for users - make sure you're ready to publish the changes and have tested the commit before pushing the tag!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,10 +23,7 @@ fi
 NAME=$(jq -r '.name' info.json)
 
 # Create the zip
-mkdir /tmp/zip
-pushd /tmp/zip
-git archive --prefix "${NAME}_$INFO_VERSION/" -o "${NAME}_$INFO_VERSION.zip" "${TAG}"
-popd
+git archive --prefix "${NAME}_$INFO_VERSION/" -o "/github/workspace/${NAME}_$INFO_VERSION.zip" "${TAG}"
 FILESIZE=$(stat --printf="%s" "${NAME}_${TAG}.zip")
 echo "File zipped, ${FILESIZE} bytes"
 unzip -v "${NAME}_${TAG}.zip"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,12 +24,8 @@ NAME=$(jq -r '.name' info.json)
 
 # Create the zip
 mkdir /tmp/zip
-ln -s /github/workspace "/tmp/zip/${NAME}_${TAG}"
 pushd /tmp/zip
-# TODO use git archive instead
-# example https://github.com/justarandomgeek/factorio-pushbutton/blob/master/makerelease.sh
-
-zip -9 -q -r "/github/workspace/${NAME}_${TAG}.zip" "${NAME}_${TAG}" -x \*.git\*
+git archive --prefix "${NAME}_$INFO_VERSION/" -o "${NAME}_$INFO_VERSION.zip" "${TAG}"
 popd
 FILESIZE=$(stat --printf="%s" "${NAME}_${TAG}.zip")
 echo "File zipped, ${FILESIZE} bytes"


### PR DESCRIPTION
I love your script!  I saw a todo and thought I'd offer some help - wanted to learn the basics of a factorio mod and along the way like to fix up things and learn.  

Short story is I've tested this and was able to push 1.0.2 of RespawnStarterArmor using git-archive (i deleted it, because it was a minor/test revision, but it works!).

I rebased to incorporate your commits before submitting the PR (the tests were done after rebase).  

Obligatory works on my box.  Let me know if you want any help with it further.